### PR TITLE
Fix resource exhausted issue

### DIFF
--- a/pkg/bu_server/api/api_server.go
+++ b/pkg/bu_server/api/api_server.go
@@ -73,7 +73,7 @@ func NewAPIWithController(apiKeyMgr auth.APIKeyAuthenticator, buMgr business_uni
 	healthRouter.HandleFunc("/health", apiServer.health).Methods(http.MethodGet)
 
 	apiRouter := r.NewRoute().Subrouter()
-	apiRouter.Use(middleware.TimeTrace, middleware.NewAPIKeyAuth(apiServer.apiKeyMgr).Authenticate)
+	apiRouter.Use(middleware.NewTimeTrace().TraceHandler, middleware.NewAPIKeyAuth(apiServer.apiKeyMgr).Authenticate)
 	apiRouter.HandleFunc("/business_unit", apiServer.createBusinessUnit).Methods(http.MethodPost)
 	apiRouter.HandleFunc("/business_unit", apiServer.listBusinessUnit).Methods(http.MethodGet)
 	apiRouter.HandleFunc("/business_unit/{id}", apiServer.getBusinessUnit).Methods(http.MethodGet)

--- a/pkg/bu_server/middleware/time_trace.go
+++ b/pkg/bu_server/middleware/time_trace.go
@@ -14,6 +14,21 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 )
 
+type TimeTrace struct {
+	durationHistogram metric.Int64Histogram
+}
+
+func NewTimeTrace() *TimeTrace {
+	histogram := otlp_util.NewInt64Histogram(
+		"observe.api.request.duration",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Request duration in milliseconds"),
+	)
+	return &TimeTrace{
+		durationHistogram: histogram,
+	}
+}
+
 type ResponseWriter struct {
 	http.ResponseWriter
 	status int
@@ -32,43 +47,30 @@ func (w *ResponseWriter) WriteHeader(status int) {
 	w.ResponseWriter.WriteHeader(status)
 }
 
-func TimeTrace(next http.Handler) http.Handler {
-	requestDuration := otlp_util.NewInt64Histogram("bu_server.api.request.duration", metric.WithDescription("Request duration in milliseconds"))
-
+func (m *TimeTrace) TraceHandler(next http.Handler) http.Handler {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "unknown"
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		clientIP := r.RemoteAddr
-		userAgent := r.UserAgent()
-		referer := r.Referer()
-		method := r.Method
-		urlPath := r.URL.Path
-
-		metricAttributes := []attribute.KeyValue{
-			semconv.NetworkPeerAddress(clientIP),
-			semconv.UserAgentName(userAgent),
-			semconv.HTTPMethod(method),
-			semconv.HTTPURL(urlPath),
-		}
-		if route := mux.CurrentRoute(r); route != nil {
-			path, _ := route.GetPathTemplate()
-			metricAttributes = append(metricAttributes, semconv.HTTPRoute(path))
-		}
+		rw := NewResponseWriter(w)
 
 		start := time.Now()
-		rw := NewResponseWriter(w)
-		next.ServeHTTP(rw, r.WithContext(ctx))
+		next.ServeHTTP(rw, r)
 		elapsed := time.Since(start).Milliseconds()
 
 		statusCode := rw.Status()
 		dataLength, _ := strconv.ParseInt(w.Header().Get("Content-Length"), 10, 64)
-		logrus.Debugf("%s - %s \"%s %s\" %d %d \"%s\" \"%s\" (%dms)", clientIP, hostname, method, urlPath, statusCode, dataLength, referer, userAgent, elapsed)
+		logrus.Debugf("%s - %s \"%s %s\" %d %d \"%s\" \"%s\" (%dms)", r.RemoteAddr, hostname, r.Method, r.URL.Path, statusCode, dataLength, r.Referer(), r.UserAgent(), elapsed)
 
-		metricAttributes = append(metricAttributes, semconv.HTTPStatusCode(statusCode))
-		requestDuration.Record(ctx, elapsed, metric.WithAttributes(metricAttributes...))
+		route := mux.CurrentRoute(r)
+		routeTemplate, _ := route.GetPathTemplate()
+		metricAttributes := []attribute.KeyValue{
+			semconv.HTTPMethod(r.Method),
+			semconv.HTTPRoute(routeTemplate),
+			semconv.HTTPStatusCode(statusCode),
+		}
+		m.durationHistogram.Record(r.Context(), elapsed, metric.WithAttributes(metricAttributes...))
 	})
 }


### PR DESCRIPTION
While sending metrics, it may suffer from `ResourceExhausted` issue. This might happen due to the varied attributes on the histogram counter.